### PR TITLE
Handle null from api

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swa-auth",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "A super-lightweight Auth library for Azure Static Web Apps.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/__tests__/auth.test.tsx
+++ b/src/__tests__/auth.test.tsx
@@ -1,64 +1,102 @@
-import { authorize, DefaultRole, User } from '../auth/auth';
+import { authorize, DefaultRole, User, getUser, DEFAULT_USER as EMPTY_USER } from '../auth/auth';
+import { server, rest, DEFAULT_USER } from '../mocks/server';
 import '@testing-library/jest-dom/extend-expect';
 import { cloneDeep } from 'lodash';
 
-const DEFAULT_TEST_USER: User = {
-  identityProvider: 'Bookface',
-  userId: '42',
-  userDetails: 'Unremarkable',
-  userRoles: [],
-};
+describe('getUser handles varying responses correctly', () => {
+  it('responds with a default user when it receives a null response', async () => {
+    server.use(
+      rest.get('/.auth/me', (_, res, ctx) => {
+        return res(ctx.json(null));
+      })
+    );
+    const user = await getUser();
+    expect(user).toEqual(EMPTY_USER);
+  });
+  it('responds with a correct user when it receives an OK response', async () => {
+    const user = await getUser();
+    expect(user).toEqual(DEFAULT_USER);
+  });
+  it("throws 'There was a problem reaching the login service. Please try again later.' when it receives a non-OK response", async () => {
+    server.use(
+      rest.get('/.auth/me', (_, res, ctx) => {
+        return res(ctx.status(400));
+      })
+    );
+    try {
+      await getUser();
+    } catch (e) {
+      expect(e.message).toEqual('There was a problem reaching the login service. Please try again later.');
+    }
+  });
+  it("throws 'There was a problem reading the response from the login service. Please try again later.' when it can't parse the JSON", async () => {
+    server.use(
+      rest.get('/.auth/me', (_, res, ctx) => {
+        return res(ctx.json({ iAmNot: 'the expected response format' }));
+      })
+    );
+    try {
+      await getUser();
+    } catch (e) {
+      expect(e.message).toEqual(
+        'There was a problem reading the response from the login service. Please try again later.'
+      );
+    }
+  });
+});
 
 describe('authorize correctly authorizes users', () => {
   test('User is authorized when holding a role other than a role listed in allowedRoles when allBut == true', () => {
-    const user: User = cloneDeep(DEFAULT_TEST_USER);
+    const user: User = cloneDeep(DEFAULT_USER);
     user.userRoles = [DefaultRole.Authenticated];
     const result = authorize([DefaultRole.Anonymous], user, true);
     expect(result).toStrictEqual(true);
   });
   test('User is authorized when holding a role other than a role listed when allBut == true, even when holding a role listed in allowedRoles', () => {
-    const user: User = cloneDeep(DEFAULT_TEST_USER);
+    const user: User = cloneDeep(DEFAULT_USER);
     user.userRoles = [DefaultRole.Authenticated, DefaultRole.Anonymous];
     const result = authorize([DefaultRole.Anonymous], user, true);
     expect(result).toStrictEqual(true);
   });
   test("User is authorized when holding a role included in the allowedRoles when allBut == false'", () => {
-    const user: User = cloneDeep(DEFAULT_TEST_USER);
+    const user: User = cloneDeep(DEFAULT_USER);
     user.userRoles = [DefaultRole.Authenticated];
     const result = authorize([DefaultRole.Authenticated, DefaultRole.GlobalAdmin], user);
     expect(result).toStrictEqual(true);
   });
   test('User is denied when not holding any roles in allowedRoles when allBut == false', () => {
-    const user: User = cloneDeep(DEFAULT_TEST_USER);
+    const user: User = cloneDeep(DEFAULT_USER);
     user.userRoles = [DefaultRole.Authenticated, DefaultRole.Anonymous];
     const result = authorize([DefaultRole.GlobalAdmin, DefaultRole.GlobalViewer], user);
     expect(result).toStrictEqual(false);
   });
   test('User is denied when holding only roles in allowedRoles when allBut == true', () => {
-    const user: User = cloneDeep(DEFAULT_TEST_USER);
+    const user: User = cloneDeep(DEFAULT_USER);
     user.userRoles = [DefaultRole.Authenticated, DefaultRole.Anonymous];
     const result = authorize([DefaultRole.Authenticated, DefaultRole.Anonymous], user, true);
     expect(result).toStrictEqual(false);
   });
   test('User is denied when holding any roles when allowedRoles is empty and allBut == false', () => {
-    const user: User = cloneDeep(DEFAULT_TEST_USER);
+    const user: User = cloneDeep(DEFAULT_USER);
     user.userRoles = [DefaultRole.Authenticated, DefaultRole.Anonymous];
     const result = authorize([], user, false);
     expect(result).toStrictEqual(false);
   });
   test('User is allowed when holding any roles when allowedRoles is empty and allBut == true', () => {
-    const user: User = cloneDeep(DEFAULT_TEST_USER);
+    const user: User = cloneDeep(DEFAULT_USER);
     user.userRoles = [DefaultRole.Authenticated, DefaultRole.Anonymous];
     const result = authorize([], user, true);
     expect(result).toStrictEqual(true);
   });
   test('User is denied when holding no roles when allowedRoles is empty and allBut == true', () => {
-    const user: User = cloneDeep(DEFAULT_TEST_USER);
+    const user: User = cloneDeep(DEFAULT_USER);
+    user.userRoles = [];
     const result = authorize([], user, true);
     expect(result).toStrictEqual(false);
   });
   test('User is denied when holding no roles when allowedRoles is empty and allBut == false', () => {
-    const user: User = cloneDeep(DEFAULT_TEST_USER);
+    const user: User = cloneDeep(DEFAULT_USER);
+    user.userRoles = [];
     const result = authorize([], user, false);
     expect(result).toStrictEqual(false);
   });

--- a/src/__tests__/hiddenComponent.test.tsx
+++ b/src/__tests__/hiddenComponent.test.tsx
@@ -1,22 +1,14 @@
 import React from 'react';
-import { DefaultRole, ProvideAuth, Roles } from '../auth/auth';
-import { server, rest, DEFAULT_USER } from '../mocks/server';
+import { DefaultRole, ProvideAuth } from '../auth/auth';
+import { server, userHandler } from '../mocks/server';
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
-import { cloneDeep } from 'lodash';
 import HiddenComponent from '../components/private_components/HiddenComponent';
 
 const SUCCESS_MESSAGE = "Success; you're authorized!";
 const RENDER_ON_AUTH = () => <div>{SUCCESS_MESSAGE}</div>;
 const AUTHENTICATING_MESSAGE = "You're authenticating, hold on!";
 const RENDER_ON_AUTHENTICATING = () => <div>{AUTHENTICATING_MESSAGE}</div>;
-const userHandler = (roles: Roles) => {
-  const CUSTOM_USER = cloneDeep(DEFAULT_USER);
-  CUSTOM_USER.userRoles = roles;
-  return rest.get('/.auth/me', (_, res, ctx) => {
-    return res(ctx.json({ clientPrincipal: CUSTOM_USER }));
-  });
-};
 
 describe('HiddenComponent correctly renders based on authorization', () => {
   it('briefly displays the default authenticating message, then displays the children.', async () => {

--- a/src/__tests__/loginOrUnauthorizedComponent.test.tsx
+++ b/src/__tests__/loginOrUnauthorizedComponent.test.tsx
@@ -1,9 +1,8 @@
 import React from 'react';
 import { DefaultRole, ProvideAuth, Roles } from '../auth/auth';
-import { server, rest, DEFAULT_USER } from '../mocks/server';
+import { server, userHandler } from '../mocks/server';
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
-import { cloneDeep } from 'lodash';
 import LoginOrUnauthorizedComponent from '../components/private_components/LoginOrUnauthorizedComponent';
 
 const SUCCESS_MESSAGE = "Success; you're authorized!";
@@ -14,13 +13,6 @@ const LOGIN_MESSAGE = "You're not logged in yet. Redirecting!";
 const RENDER_ON_LOGIN = () => <div>{LOGIN_MESSAGE}</div>;
 const UNAUTHORIZED_MESSAGE = "You're not allowed. Go away.";
 const RENDER_ON_UNAUTHORIZED = () => <div>{UNAUTHORIZED_MESSAGE}</div>;
-const userHandler = (roles: Roles) => {
-  const CUSTOM_USER = cloneDeep(DEFAULT_USER);
-  CUSTOM_USER.userRoles = roles;
-  return rest.get('/.auth/me', (_, res, ctx) => {
-    return res(ctx.json({ clientPrincipal: CUSTOM_USER }));
-  });
-};
 
 describe('LoginOrUnauthorizedComponent correctly renders based on authorization', () => {
   it('briefly displays the default authenticating message, then displays its children.', async () => {

--- a/src/__tests__/protectedComponent.test.tsx
+++ b/src/__tests__/protectedComponent.test.tsx
@@ -1,9 +1,8 @@
 import React from 'react';
-import { DefaultRole, ProvideAuth, Roles } from '../auth/auth';
-import { server, rest, DEFAULT_USER } from '../mocks/server';
+import { DefaultRole, ProvideAuth } from '../auth/auth';
+import { server, userHandler } from '../mocks/server';
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
-import { cloneDeep } from 'lodash';
 import ProtectedComponent from '../components/private_components/ProtectedComponent';
 
 const SUCCESS_MESSAGE = "Success; you're authorized!";
@@ -12,13 +11,6 @@ const AUTHENTICATING_MESSAGE = "You're authenticating, hold on!";
 const RENDER_ON_AUTHENTICATING = () => <div>{AUTHENTICATING_MESSAGE}</div>;
 const UNAUTHORIZED_MESSAGE = "You're not allowed. Go away.";
 const RENDER_ON_UNAUTHORIZED = () => <div>{UNAUTHORIZED_MESSAGE}</div>;
-const userHandler = (roles: Roles) => {
-  const CUSTOM_USER = cloneDeep(DEFAULT_USER);
-  CUSTOM_USER.userRoles = roles;
-  return rest.get('/.auth/me', (_, res, ctx) => {
-    return res(ctx.json({ clientPrincipal: CUSTOM_USER }));
-  });
-};
 
 describe('ProtectedComponent correctly renders based on authorization', () => {
   it('briefly displays the default authenticating message, then displays its children.', async () => {

--- a/src/__tests__/routers.test.tsx
+++ b/src/__tests__/routers.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Route, Switch, Redirect } from 'react-router-dom';
 import { DefaultRole, Roles } from '../auth/auth';
-import { server, rest, DEFAULT_USER } from '../mocks/server';
+import { server, userHandler } from '../mocks/server';
 import AuthMemoryRouter from '../components/router/routers/AuthMemoryRouter';
 import HiddenRoute from '../components/router/routes/HiddenRoute';
 import ProtectedRoute from '../components/router/routes/ProtectedRoute';
@@ -10,7 +10,6 @@ import LoginRedirectRoute from '../components/router/routes/LoginRedirectRoute';
 import UnauthorizedRedirectRoute from '../components/router/routes/UnauthorizedRedirectRoute';
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
-import { cloneDeep } from 'lodash';
 
 const SUCCESS_MESSAGE = "Success; you're authorized!";
 const RENDER_ON_AUTH = () => <div>{SUCCESS_MESSAGE}</div>;
@@ -20,13 +19,6 @@ const LOGIN_MESSAGE = "You're not logged in yet. Redirecting!";
 const RENDER_ON_LOGIN = () => <div>{LOGIN_MESSAGE}</div>;
 const UNAUTHORIZED_MESSAGE = "You're not allowed. Go away.";
 const RENDER_ON_UNAUTHORIZED = () => <div>{UNAUTHORIZED_MESSAGE}</div>;
-const userHandler = (roles: Roles) => {
-  const CUSTOM_USER = cloneDeep(DEFAULT_USER);
-  CUSTOM_USER.userRoles = roles;
-  return rest.get('/.auth/me', (_, res, ctx) => {
-    return res(ctx.json({ clientPrincipal: CUSTOM_USER }));
-  });
-};
 
 describe('Randome AuthRouter features work correctly', () => {
   it('handles route bouncing like it should', async () => {

--- a/src/auth/auth.tsx
+++ b/src/auth/auth.tsx
@@ -81,6 +81,23 @@ export type User = {
 
 const authContext = createContext<AuthorizationContext>(DEFAULT_AUTH_CONTEXT);
 
+const getUser = async (): Promise<User> => {
+  const resp = await fetch(`/.auth/me`);
+  if (!resp.ok) {
+    throw Error('There was a problem reaching the login service. Please try again later.');
+  }
+  const json = await resp.json();
+  if (json === null) {
+    return DEFAULT_USER;
+  }
+  try {
+    const user: User = json.clientPrincipal;
+    return user;
+  } catch (e) {
+    throw Error('There was a problem reading the response from the login service. Please try again later.');
+  }
+};
+
 export interface ProvideAuthProps {
   disallowedLoginProviders?: LoginProvider[];
   children: React.ReactNode;
@@ -96,19 +113,6 @@ const ProvideAuth = ({ disallowedLoginProviders, children }: ProvideAuthProps): 
   const [user, setUser] = useState(DEFAULT_USER);
   const [isLoggedIn, setIsLoggedIn] = useState(DEFAULT_AUTH_CONTEXT.isLoggedIn);
   const [isAuthenticating, setIsAuthenticating] = useState(DEFAULT_AUTH_CONTEXT.isAuthenticating);
-
-  const getUser = async (): Promise<User> => {
-    const resp = await fetch(`/.auth/me`);
-    if (!resp.ok) {
-      throw Error('There was a problem reaching the login service. Please try again later.');
-    }
-    try {
-      const json: User = (await resp.json()).clientPrincipal;
-      return json;
-    } catch (e) {
-      throw Error('There was a problem reading the response from the login service. Please try again later.');
-    }
-  };
 
   const forwardToAuth = (uri: string): void => {
     const url = `${window.location.origin}/.auth/${uri}`;
@@ -211,4 +215,4 @@ const authorize = (allowedRoles: Roles, user: User, allBut = false): boolean => 
   return authorized;
 };
 
-export { ProvideAuth, useAuth, authorize, DEFAULT_AUTH_CONTEXT };
+export { ProvideAuth, useAuth, authorize, getUser, DEFAULT_AUTH_CONTEXT, DEFAULT_USER };

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -1,11 +1,20 @@
 import { rest } from 'msw';
-import { User, DefaultRole } from '../auth/auth';
+import { User, DefaultRole, Roles } from '../auth/auth';
+import { cloneDeep } from 'lodash';
 
 const DEFAULT_USER: User = {
   identityProvider: 'aad',
   userId: '420',
   userDetails: 'Unremarkable',
   userRoles: [DefaultRole.Anonymous, DefaultRole.Authenticated],
+};
+
+const userHandler = (roles: Roles) => {
+  const CUSTOM_USER = cloneDeep(DEFAULT_USER);
+  CUSTOM_USER.userRoles = roles;
+  return rest.get('/.auth/me', (_, res, ctx) => {
+    return res(ctx.json({ clientPrincipal: CUSTOM_USER }));
+  });
 };
 
 const handlers = [
@@ -19,4 +28,4 @@ const handlers = [
   // }),
 ];
 
-export { handlers, DEFAULT_USER };
+export { handlers, userHandler, DEFAULT_USER };

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -9,8 +9,9 @@ const DEFAULT_USER: User = {
   userRoles: [DefaultRole.Anonymous, DefaultRole.Authenticated],
 };
 
+/* eslint-disable */
 const userHandler = (roles: Roles) => {
-  // eslint-disable-line
+  /* eslint-enable */
   const CUSTOM_USER = cloneDeep(DEFAULT_USER);
   CUSTOM_USER.userRoles = roles;
   return rest.get('/.auth/me', (_, res, ctx) => {

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -10,6 +10,7 @@ const DEFAULT_USER: User = {
 };
 
 const userHandler = (roles: Roles) => {
+  // eslint-disable-line
   const CUSTOM_USER = cloneDeep(DEFAULT_USER);
   CUSTOM_USER.userRoles = roles;
   return rest.get('/.auth/me', (_, res, ctx) => {

--- a/src/mocks/server.ts
+++ b/src/mocks/server.ts
@@ -1,7 +1,7 @@
 import { rest } from 'msw';
 import { setupServer } from 'msw/node';
-import { handlers, DEFAULT_USER } from './handlers';
+import { handlers, userHandler, DEFAULT_USER } from './handlers';
 
 const server = setupServer(...handlers);
 
-export { server, rest, DEFAULT_USER };
+export { server, userHandler, rest, DEFAULT_USER };


### PR DESCRIPTION
Updated logic to explicitly handle null responses from /.auth/me. This indicates a user is not logged in, which, in internal state, should be represented by a default user with an empty array for roles.